### PR TITLE
Delete review and remove rating for current user.

### DIFF
--- a/BabyBrunch/Models/ReviewData.swift
+++ b/BabyBrunch/Models/ReviewData.swift
@@ -14,4 +14,6 @@ struct ReviewData : Codable, Identifiable, Hashable {
     var rating : Int
     var userId : String
     var userName : String?
+    var pinId : String?
+    var pinName : String?
 }

--- a/BabyBrunch/Views/AddReviewView.swift
+++ b/BabyBrunch/Views/AddReviewView.swift
@@ -105,36 +105,8 @@ struct AddReviewView: View {
                                         print("newAverage inside if let success, let newAverage: \(newAverage)")
                                         print("Added rating: \(rating)")
                                         
-                                        // Check if annotation exists on mapView by comparing pin id.
-                                        // If it exists, cast MKAnnotation to a PinAnnotation and create a new variable storing the data.
-                                        if let oldAnnotation = mapView.annotations.first(where: {
-                                            guard let pinAnnotation = $0 as? PinAnnotation else { return false }
-                                            return pinAnnotation.pin?.id == pin.id
-                                        }) as? PinAnnotation, let oldPin = oldAnnotation.pin {
-                                            
-                                            let newAnnotation = PinAnnotation(pin: oldPin) // Create a new annotation with the same data as the old pin (using custom init in PinAnnotation).
-                                            newAnnotation.subtitle = String(format: "⭐️: %.1f", newAverage) // Update subtitle with new averageRating received from callback in mapVM.addRating above.
-                                            
-                                            DispatchQueue.main.async {
-                                                mapView.removeAnnotation(oldAnnotation) // Remove the old pin from the map.
-                                                mapView.addAnnotation(newAnnotation) // Add the new pin to the map.
-                                            }
-                                        } else {
-                                            print("No existing annotation found to update.")
-                                        }
-                                        
-                                        //                                    if !reviewText.isEmpty {
-                                        //                                        mapVM.addReview(pin: pin, review: reviewText, rating: rating, userName: userName) { success in
-                                        //                                            if success {
-                                        //                                                print("Added review: \(reviewText)")
-                                        //                                                dismiss()
-                                        //                                            } else {
-                                        //                                                print("No success")
-                                        //                                            }
-                                        //                                        }
-                                        //                                    } else {
-                                        //                                       dismiss()
-                                        //                                    }
+                                        // Call function to update pin average rating on map.
+                                        mapVM.updateAnnoatation(mapView: mapView, pin: pin, newAverage: newAverage)
                                     }
                                 } reviewExists: { exists in
                                     if exists {

--- a/BabyBrunch/Views/TabViews/MainTabView.swift
+++ b/BabyBrunch/Views/TabViews/MainTabView.swift
@@ -42,11 +42,16 @@ struct MainTabView: View {
                         Image(systemName: "heart")
                     }
                     .tag(3)
+                UserReviewsView(mapViewRef: $mapViewRef)
+                    .tabItem {
+                        Image(systemName: "rectangle.and.pencil.and.ellipsis")
+                    }
+                    .tag(4)
                 PublicFavouritesView(mapViewRef: $mapViewRef)
                     .tabItem {
                         Image(systemName: "globe")
                     }
-                    .tag(4)
+                    .tag(5)
             }
         }.accentColor(Color(.oldRose))
             .onAppear(){

--- a/BabyBrunch/Views/UserReviewsView.swift
+++ b/BabyBrunch/Views/UserReviewsView.swift
@@ -1,0 +1,94 @@
+//
+//  UserReviewsView.swift
+//  BabyBrunch
+//
+//  Created by KiwiComp on 2025-06-05.
+//
+
+import SwiftUI
+import MapKit
+
+struct UserReviewsView: View {
+
+    @State var userReviewList : [ReviewData] = []
+    @StateObject var mapVM = MapViewModel()
+    @Binding var mapViewRef : MKMapView?
+    
+    var body: some View {
+        ZStack {
+            Color(.lavenderBlush)
+            VStack {
+                CustomTitle(title: "Your reviews")
+                
+                List {
+                    ForEach(userReviewList, id: \.pinName) { review in
+                        UserReviews(review: review)
+                    }.onDelete(perform: deleteReview)
+                }.scrollContentBackground(.hidden)
+            }
+        }
+        .onAppear {
+            mapVM.fetchReviewsByCurrentUser { list in
+                userReviewList = list
+            }
+        }
+    }
+    
+    func deleteReview(at indexSet: IndexSet) {
+        // Iterate over each index in the IndexSet sent into the function.
+        for index in indexSet {
+            let reviewToDelete = userReviewList[index]
+            
+            // Call function to deleteReview in mapVM. If returning bool is true, execute more code.
+            mapVM.deleteReview(pinId: reviewToDelete.pinId ?? "") { success in
+                if success {
+                    // Call function to removeRating in mapVM, which has a callback with three variabels: if success is true, use the fetched pin to remove and create annotation for that pin with the new average.
+                    mapVM.removeRating(from: reviewToDelete.pinId ?? "", ratingToRemove: reviewToDelete.rating) { success, newAverage, fetchedPin in
+                        if success {
+                            if let mapView = mapViewRef, let newAverage = newAverage, let pin = fetchedPin {
+                                // Call function to updateAnnotation on map to display new average for the pin.
+                                mapVM.updateAnnoatation(mapView: mapView, pin: pin, newAverage: newAverage)
+                            }
+                            // On the main thread, remove the review to delete from the local list.
+                            DispatchQueue.main.async {
+                                userReviewList.remove(atOffsets: indexSet)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+//#Preview {
+//    UserReviewsView()
+//}
+
+struct UserReviews : View {
+    let review : ReviewData
+    
+    var body : some View {
+        VStack(alignment: .leading){
+            HStack {
+                Text(review.pinName ?? "errorPinName")
+                    .font(.headline)
+                    .padding(.top, 5)
+                    .foregroundColor(Color(.raisinBlack))
+                
+                StarsView(rating: Double(review.rating))
+            }
+            .bold()
+            .padding(.bottom, 7)
+            
+            Text(review.text)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(.leading, 20)
+        .frame(width: UIScreen.main.bounds.width * 0.8, height: 150, alignment: .topLeading)
+        .background(Color(.thistle))
+        .cornerRadius(10)
+    }
+}


### PR DESCRIPTION
- Created new view (UserReviewsView) to display all of the current user's reviews, accessed through tab view.
- Swipe delete function on list in UserReviewsView to delete locally as well as on Firestore. 
- Updated ReviewData model to include pinId and pinName. 
- Created functions in MapVM to fetch user's reviews, delete a review and remove a rating for the pin. 
- Updated functions in MapVM to work with the updated ReviewData model. 
- Moved code to create and delete an annotation from AddReviewView to function in mapVM, since it had to be used in UsersReviewsView as well.